### PR TITLE
ua_device regex better samsung support

### DIFF
--- a/go/example/example.go
+++ b/go/example/example.go
@@ -1,12 +1,21 @@
 package main
 
 import (
-	"../uaparser" // You could change this to a github repo as well
 	"fmt"
+	"io/ioutil"
+	"os" // You could change this to a github repo as well
+
+	"../uaparser"
 )
 
 func main() {
-	testStr := "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
+	testBytes, err := ioutil.ReadAll(os.Stdin)
+
+	if err != nil {
+		panic(err)
+	}
+
+	testStr := string(testBytes)
 	regexFile := "../../regexes.yaml"
 	parser := uaparser.New(regexFile)
 	client := parser.Parse(testStr)

--- a/go/example/example.go
+++ b/go/example/example.go
@@ -1,21 +1,12 @@
 package main
 
 import (
+	"../uaparser" // You could change this to a github repo as well
 	"fmt"
-	"io/ioutil"
-	"os" // You could change this to a github repo as well
-
-	"../uaparser"
 )
 
 func main() {
-	testBytes, err := ioutil.ReadAll(os.Stdin)
-
-	if err != nil {
-		panic(err)
-	}
-
-	testStr := string(testBytes)
+	testStr := "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.1.0-80) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true"
 	regexFile := "../../regexes.yaml"
 	parser := uaparser.New(regexFile)
 	client := parser.Parse(testStr)

--- a/regexes.yaml
+++ b/regexes.yaml
@@ -1242,6 +1242,12 @@ device_parsers:
     device_replacement: 'Samsung $1'
   - regex: 'SAMSUNG\; ([A-Za-z0-9\-]+)'
     device_replacement: 'Samsung $1'
+  - regex: 'samsung-([A-Za-z0-9\-]+)'
+    device_replacement: 'Samsung $1'
+  - regex: 'samsung\; ([A-Za-z0-9\-]+)'
+    device_replacement: 'Samsung $1'
+  - regex: 'samsung\s([A-Za-z0-9\-]+)'
+    device_replacement: 'Samsung $1'
 
   ##########
   # Sega


### PR DESCRIPTION
The regexes are falling for a lot of samsung devices, where
the vendor name is lowercase.

Example:

```
SoundCloud-Android/15.06.09-release (Android 5.0.1; samsung SM-N910P)
```

I am not familiar with java so I don't know how to actually test it, but I was able to reproduce it and fix it using the go version.
